### PR TITLE
Add script to train Warrior Mages' Summoning skill

### DIFF
--- a/summon.cmd
+++ b/summon.cmd
@@ -1,0 +1,32 @@
+# Simple script to train Warrior Mage's Summoning skill.
+# Summon admittance / impedance until mind locked.
+# debuglevel 5
+
+start:
+  var summon_action impedance
+  goto summon
+
+summon:
+  gosub summon_exp_check
+  matchre set_action_to_admittance briefly increasing|further increasing|cannot discharge|you have exhausted your planar charge
+  matchre set_action_to_impedance briefly decreasing|further decreasing|so heavily embody
+  pause 0.5
+  put summon %summon_action
+  matchwait 30
+  goto summon
+
+set_action_to_admittance:
+  var summon_action admittance
+  goto summon
+
+set_action_to_impedance:
+  var summon_action impedance
+  goto summon
+
+summon_exp_check:
+  if $Summoning.LearningRate >= 34 then goto move_out
+  return
+
+move_out:
+  pause 2
+  put #parse SUMMONING DONE


### PR DESCRIPTION
The script repeatedly actives `summon impedance` to reduce elemental charge to its minimum.

Once the minimum is reached, `summon admittance` repeats until elemental charge reaches its maximum.

The script loops like this until the Summoning skill is Mind Locked.