### PR TITLE
Improve automapper's handling of stairs on Aesry

### DIFF
--- a/automapper.cmd
+++ b/automapper.cmd
@@ -31,10 +31,20 @@ go:
   go.retry:
     matchre return ^Obvious (paths|exits)|^It's pitch dark
     matchre go.retry ^\.\.\.wait|^Sorry, you may only|^Sorry, system is slow|^You can't ride your \w+ broom in that direction
+    matchre on_steps You begin climbing|You really should concentrate
     matchre retreat ^You are engaged
     put %dir
     matchwait 3
     goto go.retry
+
+on_steps:
+  matchre finished_steps You reach the end
+  matchwait 30
+  return
+
+finished_steps:
+  pause 1
+  return
 
 retreat:
   put retreat


### PR DESCRIPTION
Instead of retrying every 3 seconds when climbing stairs, wait for the message that you've
reached the end of the stairs for up to 30 seconds.

Retrying every 3 seconds would occasionally break the travel script if
the retry was sent just as you reached the end of the stairs and you
would then climb back the way you just came.